### PR TITLE
Formatted, clarified variable names, added missing `final` in `compar…

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/COMP2522-Date-Class.iml" filepath="$PROJECT_DIR$/COMP2522-Date-Class.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/COMP2522-Date-Class.iml
+++ b/COMP2522-Date-Class.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Date.java
+++ b/Date.java
@@ -1,4 +1,3 @@
-
 /**
  * Date represents a date including of a year, month and day. It has
  * methods to retrieve the specified year, month or day and methods to
@@ -8,75 +7,76 @@
  * @author Carl M
  * @author Jonathan Y
  * @author Alex H
- * @version 1.3
+ * @author Glenn D
+ * @author Szymon Z
+ * @version 1.4
  */
-public class Date
-        implements Printable, Comparable<Date>
+public class Date implements Printable, Comparable<Date>
 {
-    public static final int CURRENT_YEAR = 2025;
-    public static final int MINIMUM_YEAR = 1800;
+    public static final int YEAR_CURRENT = 2025;
+    public static final int YEAR_MINIMUM = 1800;
 
     private static final int EVEN_CHECK = 2;
-    private static final int EVEN = 0;
-    private static final int ODD = 1;
+    private static final int EVEN       = 0;
+    private static final int ODD        = 1;
 
-    private static final int YEAR_PLACEMENT = 1000;
-    private static final int MILLENNIA_CHECK = 100;
+    private static final int YEAR_PLACEMENT   = 1000;
+    private static final int MILLENNIA_CHECK  = 100;
     private static final int REMOVE_MILLENNIA = 1000;
-    private static final int MILLENNIA_2000S = 20;
-    private static final int MILLENNIA_1800S = 18;
-    private static final int LEAP_YEAR_CHECK = 4;
-    private static final int LEAP_YEAR = 0;
+    private static final int MILLENNIA_2000S  = 20;
+    private static final int MILLENNIA_1800S  = 18;
+    private static final int LEAP_YEAR_CHECK  = 4;
+    private static final int LEAP_YEAR        = 0;
 
-    private static final int MINIMUM_MONTH = 1;
-    private static final int MAXIMUM_MONTH = 12;
-    private static final int MONTH_PLACEMENT = 100;
+    private static final int MONTH_MINIMUM        = 1;
+    private static final int MONTH_MAXIMUM        = 12;
+    private static final int MONTH_PLACEMENT      = 100;
     private static final int MONTH_MIDYEAR_SWITCH = 7;
 
-    private static final int MINIMUM_DAY = 1;
-    private static final int MAXIMUM_DAY_LONG = 31;
-    private static final int MAXIMUM_DAY_SHORT = 30;
-    private static final int MAXIMUM_DAY_FEBRUARY = 28;
-    private static final int MAXIMUM_DAY_FEB_LEAP_YEAR = 29;
+    private static final int DAY_MINIMUM                    = 1;
+    private static final int DAY_MAXIMUM_LONG               = 31;
+    private static final int DAY_MAXIMUM_SHORT              = 30;
+    private static final int DAY_FEBRUARY_MAXIMUM           = 28;
+    private static final int DAY_FEBRUARY_MAXIMUM_LEAP_YEAR = 29;
 
-    private static final int JANUARY_NUM = 1;
-    private static final int FEBRUARY_NUM = 2;
-    private static final int MARCH_NUM = 3;
-    private static final int APRIL_NUM = 4;
-    private static final int MAY_NUM = 5;
-    private static final int JUNE_NUM = 6;
-    private static final int JULY_NUM = 7;
-    private static final int AUGUST_NUM = 8;
-    private static final int SEPTEMBER_NUM = 9;
-    private static final int OCTOBER_NUM = 10;
-    private static final int NOVEMBER_NUM = 11;
-    private static final int DECEMBER_NUM = 12;
+    private static final int NUM_JANUARY   = 1;
+    private static final int NUM_FEBRUARY  = 2;
+    private static final int NUM_MARCH     = 3;
+    private static final int NUM_APRIL     = 4;
+    private static final int NUM_MAY       = 5;
+    private static final int NUM_JUNE      = 6;
+    private static final int NUM_JULY      = 7;
+    private static final int NUM_AUGUST    = 8;
+    private static final int NUM_SEPTEMBER = 9;
+    private static final int NUM_OCTOBER   = 10;
+    private static final int NUM_NOVEMBER  = 11;
+    private static final int NUM_DECEMBER  = 12;
 
-    private static final int JANUARY_MONTH_CODE = 1;
-    private static final int FEBRUARY_MONTH_CODE = 4;
-    private static final int MARCH_MONTH_CODE = 4;
-    private static final int APRIL_MONTH_CODE = 0;
-    private static final int MAY_MONTH_CODE = 2;
-    private static final int JUNE_MONTH_CODE = 5;
-    private static final int JULY_MONTH_CODE = 0;
-    private static final int AUGUST_MONTH_CODE = 3;
-    private static final int SEPTEMBER_MONTH_CODE = 6;
-    private static final int OCTOBER_MONTH_CODE = 1;
-    private static final int NOVEMBER_MONTH_CODE = 4;
-    private static final int DECEMBER_MONTH_CODE = 6;
+    private static final int MONTH_CODE_JANUARY   = 1;
+    private static final int MONTH_CODE_FEBRUARY  = 4;
+    private static final int MONTH_CODE_MARCH     = 4;
+    private static final int MONTH_CODE_APRIL     = 0;
+    private static final int MONTH_CODE_MAY       = 2;
+    private static final int MONTH_CODE_JUNE      = 5;
+    private static final int MONTH_CODE_JULY      = 0;
+    private static final int MONTH_CODE_AUGUST    = 3;
+    private static final int MONTH_CODE_SEPTEMBER = 6;
+    private static final int MONTH_CODE_OCTOBER   = 1;
+    private static final int MONTH_CODE_NOVEMBER  = 4;
+    private static final int MONTH_CODE_DECEMBER  = 6;
 
-    private static final int SATURDAY_CODE = 0;
-    private static final int SUNDAY_CODE = 1;
-    private static final int MONDAY_CODE = 2;
-    private static final int TUESDAY_CODE = 3;
-    private static final int WEDNESDAY_CODE = 4;
-    private static final int THURSDAY_CODE = 5;
-    private static final int FRIDAY_CODE = 6;
+    private static final int CODE_SATURDAY  = 0;
+    private static final int CODE_SUNDAY    = 1;
+    private static final int CODE_MONDAY    = 2;
+    private static final int CODE_TUESDAY   = 3;
+    private static final int CODE_WEDNESDAY = 4;
+    private static final int CODE_THURSDAY  = 5;
+    private static final int CODE_FRIDAY    = 6;
 
-    private static final int NUM_OF_DAYS_IN_WEEK = 7;
-    private static final int DAY_OF_WEEK_STEP3 = 4;
-    private static final int EXTRA_CALC_2000S = 6;
-    private static final int EXTRA_CALC_1800S = 2;
+    private static final int NUM_DAYS_IN_WEEK     = 7;
+    private static final int DAY_OF_WEEK_STEP3    = 4;
+    private static final int EXTRA_CALC_2000S     = 6;
+    private static final int EXTRA_CALC_1800S     = 2;
     private static final int EXTRA_CALC_LEAP_YEAR = 6;
 
     private final int year;
@@ -87,9 +87,9 @@ public class Date
      * Constructs a date object with a year, month and day and validates
      * that each value is valid.
      *
-     * @param year the date object's year.
+     * @param year  the date object's year.
      * @param month the date object's month.
-     * @param day the date object's day.
+     * @param day   the date object's day.
      */
     public Date(final int year,
                 final int month,
@@ -97,69 +97,89 @@ public class Date
     {
         validateYear(year);
         validateMonth(month);
-        validateDay(year, month, day);
+        validateDay(year,
+                    month,
+                    day);
 
 
-        this.year = year;
+        this.year  = year;
         this.month = month;
-        this.day = day;
+        this.day   = day;
     }
 
     /**
      * Returns the date object's day.
+     *
      * @return day, the date object's day.
      */
-    public int getDay() { return day; }
+    public int getDay()
+    {
+        return day;
+    }
 
     /**
      * Returns the date object's month.
+     *
      * @return month, the date object's month.
      */
-    public int getMonth() { return month; }
+    public int getMonth()
+    {
+        return month;
+    }
 
     /**
      * Returns the date object's year.
+     *
      * @return year, the date object's year.
      */
-    public int getYear() { return year; }
+    public int getYear()
+    {
+        return year;
+    }
 
     /**
      * Converts the date object's year, month and day into a YYYYMMDD format.
+     *
      * @return YYYYMMDD, the date object's year, month and day in YYYYMMDD format.
      */
     public int getYYYYMMDD()
     {
         int YYYYMMDD;
+
         YYYYMMDD = year * YEAR_PLACEMENT;
         YYYYMMDD += month * MONTH_PLACEMENT;
         YYYYMMDD += day;
+
         return YYYYMMDD;
     }
+
 
     /**
      * Converts the date object's year, month and day integers into a String Month Day, Year format.
      * ex. January 1, 2025
+     *
      * @return the date as a String Month Day, Year
      */
-    public String getMDY() {
+    public String getMDY()
+    {
         final StringBuilder sb;
 
         sb = new StringBuilder();
 
-        switch (month)
+        switch(month)
         {
-            case JANUARY_NUM -> sb.append("January");
-            case FEBRUARY_NUM -> sb.append("February");
-            case MARCH_NUM -> sb.append("March");
-            case APRIL_NUM -> sb.append("April");
-            case MAY_NUM -> sb.append("May");
-            case JUNE_NUM -> sb.append("June");
-            case JULY_NUM -> sb.append("July");
-            case AUGUST_NUM -> sb.append("August");
-            case SEPTEMBER_NUM -> sb.append("September");
-            case OCTOBER_NUM -> sb.append("October");
-            case NOVEMBER_NUM -> sb.append("November");
-            case DECEMBER_NUM -> sb.append("December");
+            case NUM_JANUARY -> sb.append("January");
+            case NUM_FEBRUARY -> sb.append("February");
+            case NUM_MARCH -> sb.append("March");
+            case NUM_APRIL -> sb.append("April");
+            case NUM_MAY -> sb.append("May");
+            case NUM_JUNE -> sb.append("June");
+            case NUM_JULY -> sb.append("July");
+            case NUM_AUGUST -> sb.append("August");
+            case NUM_SEPTEMBER -> sb.append("September");
+            case NUM_OCTOBER -> sb.append("October");
+            case NUM_NOVEMBER -> sb.append("November");
+            case NUM_DECEMBER -> sb.append("December");
             default -> throw new IllegalArgumentException("month is not a valid month in the year (1-12)");
         }
 
@@ -190,6 +210,7 @@ public class Date
      * <li>All dates in the 2000's, add 6 at the start.</li>
      * <li>All dates in the 1800's add 2 at the start.</li>
      * </p>
+     *
      * @return dayOfTheWeek, the day of the week as a number from 0-6 which converts to Saturday-Friday.
      */
     public int getDayOfTheWeek()
@@ -197,13 +218,17 @@ public class Date
         final int yearDigits;
         final int maxDays;
         final int monthCode;
-        int dayOfTheWeek;
+        final int dayOfTheWeek;
 
         yearDigits = getLastTwoDigitsOfYear(year);
-        maxDays = getMaximumDaysInMonth(month);
-        monthCode = getMonthCode(month);
+        maxDays    = getMaximumDaysInMonth(month);
+        monthCode  = getMonthCode(month);
 
-        dayOfTheWeek = dayOfTheWeekCalculation(yearDigits, maxDays, monthCode, year, month);
+        dayOfTheWeek = dayOfTheWeekCalculation(yearDigits,
+                                               maxDays,
+                                               monthCode,
+                                               year,
+                                               month);
 
         return dayOfTheWeek;
     }
@@ -222,47 +247,51 @@ public class Date
      * Compares this Date to the given Date.
      * if both years are equal, then returns difference in months.
      * if months are equal, it returns the difference in days.
-     * @param d the object to be compared.
+     *
+     * @param compareDate the object to be compared.
      * @return difference as an int
      */
     @Override
-    public int compareTo(Date d)
+    public int compareTo(final Date compareDate)
     {
-        if(d == null)
+        if(compareDate == null)
         {
             throw new IllegalArgumentException("Date cannot be null");
         }
 
-        if(getYear() != d.getYear())
+        if(getYear() != compareDate.getYear())
         {
-            return getYear() - d.getYear();
+            return getYear() - compareDate.getYear();
         }
-        else if(getMonth() != d.getMonth())
+
+        if(getMonth() != compareDate.getMonth())
         {
-            return getMonth() - d.getMonth();
+            return getMonth() - compareDate.getMonth();
         }
         else
         {
-            return getDay() - d.getDay();
+            return getDay() - compareDate.getDay();
         }
     }
 
     /**
      * Returns the day of the week in its word form or String form.
+     *
      * @return the day of the week as a word
      */
-    public String DayOfTheWeekStr() {
+    public String DayOfTheWeekStr()
+    {
         final String dayStr;
 
-        switch (this.getDayOfTheWeek())
+        switch(this.getDayOfTheWeek())
         {
-            case SATURDAY_CODE -> dayStr = "Saturday";
-            case SUNDAY_CODE -> dayStr = "Sunday";
-            case MONDAY_CODE -> dayStr = "Monday";
-            case TUESDAY_CODE -> dayStr = "Tuesday";
-            case WEDNESDAY_CODE -> dayStr = "Wednesday";
-            case THURSDAY_CODE -> dayStr = "Thursday";
-            case FRIDAY_CODE -> dayStr = "Friday";
+            case CODE_SATURDAY -> dayStr = "Saturday";
+            case CODE_SUNDAY -> dayStr = "Sunday";
+            case CODE_MONDAY -> dayStr = "Monday";
+            case CODE_TUESDAY -> dayStr = "Tuesday";
+            case CODE_WEDNESDAY -> dayStr = "Wednesday";
+            case CODE_THURSDAY -> dayStr = "Thursday";
+            case CODE_FRIDAY -> dayStr = "Friday";
             default -> dayStr = "0";
         }
 
@@ -279,33 +308,35 @@ public class Date
 
         dayOfTheWeek = 0;
 
-        if (year / MILLENNIA_CHECK == MILLENNIA_2000S)
+        if(year / MILLENNIA_CHECK == MILLENNIA_2000S)
         {
             dayOfTheWeek += EXTRA_CALC_2000S;
         }
-
-        else if (year / MILLENNIA_CHECK == MILLENNIA_1800S)
+        else if(year / MILLENNIA_CHECK == MILLENNIA_1800S)
         {
             dayOfTheWeek += EXTRA_CALC_1800S;
         }
-
-        else if (isLeapYear(year) && month <= FEBRUARY_NUM)
+        else if(isLeapYear(year) && month <= NUM_FEBRUARY)
         {
             dayOfTheWeek += EXTRA_CALC_LEAP_YEAR;
         }
-        dayOfTheWeek += yearDigits / MAXIMUM_MONTH;
-        dayOfTheWeek += yearDigits % MAXIMUM_MONTH;
-        dayOfTheWeek += (yearDigits % MAXIMUM_MONTH) / DAY_OF_WEEK_STEP3;
+
+        dayOfTheWeek += yearDigits / MONTH_MAXIMUM;
+        dayOfTheWeek += yearDigits % MONTH_MAXIMUM;
+        dayOfTheWeek += (yearDigits % MONTH_MAXIMUM) / DAY_OF_WEEK_STEP3;
         dayOfTheWeek += maxDays;
         dayOfTheWeek += monthCode;
-        dayOfTheWeek %= NUM_OF_DAYS_IN_WEEK;
+        dayOfTheWeek %= NUM_DAYS_IN_WEEK;
+
         return dayOfTheWeek;
     }
 
     private static int getLastTwoDigitsOfYear(final int year)
     {
         int lastTwoDigits;
+
         lastTwoDigits = (year / MILLENNIA_CHECK) * REMOVE_MILLENNIA;
+
         return lastTwoDigits;
     }
 
@@ -315,26 +346,26 @@ public class Date
 
         maximumDays = 0;
 
-        if (month <= MONTH_MIDYEAR_SWITCH)
+        if(month <= MONTH_MIDYEAR_SWITCH)
         {
-            if (month % EVEN_CHECK == ODD)
+            if(month % EVEN_CHECK == ODD)
             {
-                maximumDays = MAXIMUM_DAY_LONG;
+                maximumDays = DAY_MAXIMUM_LONG;
             }
-            else if (month % EVEN_CHECK == EVEN)
+            else if(month % EVEN_CHECK == EVEN)
             {
-                maximumDays = MAXIMUM_DAY_SHORT;
+                maximumDays = DAY_MAXIMUM_SHORT;
             }
         }
         else
         {
-            if (month % EVEN_CHECK == EVEN)
+            if(month % EVEN_CHECK == EVEN)
             {
-                maximumDays = MAXIMUM_DAY_LONG;
+                maximumDays = DAY_MAXIMUM_LONG;
             }
             else
             {
-                maximumDays = MAXIMUM_DAY_SHORT;
+                maximumDays = DAY_MAXIMUM_SHORT;
             }
         }
 
@@ -344,20 +375,21 @@ public class Date
     private static int getMonthCode(final int month)
     {
         int monthCode;
-        switch (month)
+
+        switch(month)
         {
-            case JANUARY_NUM -> monthCode = JANUARY_MONTH_CODE;
-            case FEBRUARY_NUM -> monthCode = FEBRUARY_MONTH_CODE;
-            case MARCH_NUM -> monthCode = MARCH_MONTH_CODE;
-            case APRIL_NUM -> monthCode = APRIL_MONTH_CODE;
-            case MAY_NUM -> monthCode = MAY_MONTH_CODE;
-            case JUNE_NUM -> monthCode = JUNE_MONTH_CODE;
-            case JULY_NUM -> monthCode = JULY_MONTH_CODE;
-            case AUGUST_NUM -> monthCode = AUGUST_MONTH_CODE;
-            case SEPTEMBER_NUM -> monthCode = SEPTEMBER_MONTH_CODE;
-            case OCTOBER_NUM -> monthCode = OCTOBER_MONTH_CODE;
-            case NOVEMBER_NUM -> monthCode = NOVEMBER_MONTH_CODE;
-            case DECEMBER_NUM -> monthCode = DECEMBER_MONTH_CODE;
+            case NUM_JANUARY -> monthCode = MONTH_CODE_JANUARY;
+            case NUM_FEBRUARY -> monthCode = MONTH_CODE_FEBRUARY;
+            case NUM_MARCH -> monthCode = MONTH_CODE_MARCH;
+            case NUM_APRIL -> monthCode = MONTH_CODE_APRIL;
+            case NUM_MAY -> monthCode = MONTH_CODE_MAY;
+            case NUM_JUNE -> monthCode = MONTH_CODE_JUNE;
+            case NUM_JULY -> monthCode = MONTH_CODE_JULY;
+            case NUM_AUGUST -> monthCode = MONTH_CODE_AUGUST;
+            case NUM_SEPTEMBER -> monthCode = MONTH_CODE_SEPTEMBER;
+            case NUM_OCTOBER -> monthCode = MONTH_CODE_OCTOBER;
+            case NUM_NOVEMBER -> monthCode = MONTH_CODE_NOVEMBER;
+            case NUM_DECEMBER -> monthCode = MONTH_CODE_DECEMBER;
             default -> throw new IllegalArgumentException("month is not a valid month in the year (1-12)");
         }
         return monthCode;
@@ -365,8 +397,7 @@ public class Date
 
     private static void validateYear(final int year)
     {
-        if (year < MINIMUM_YEAR ||
-                year > CURRENT_YEAR)
+        if(year < YEAR_MINIMUM || year > YEAR_CURRENT)
         {
             throw new IllegalArgumentException("Invalid Year " + year);
         }
@@ -374,8 +405,8 @@ public class Date
 
     private static void validateMonth(final int month)
     {
-        if (month < MINIMUM_MONTH ||
-                month > MAXIMUM_MONTH) {
+        if(month < MONTH_MINIMUM || month > MONTH_MAXIMUM)
+        {
             throw new IllegalArgumentException("Invalid Month " + month);
         }
     }
@@ -384,23 +415,23 @@ public class Date
                                     final int month,
                                     final int day)
     {
-        if (day < MINIMUM_DAY)
+        if(day < DAY_MINIMUM)
         {
             throw new IllegalArgumentException("Invalid day " + day);
         }
-        else if (day > getMaximumDaysInMonth(month))
+
+        if(day > getMaximumDaysInMonth(month))
         {
             throw new IllegalArgumentException("Invalid day " + day + " for month");
         }
-        else if (month == FEBRUARY_NUM)
+
+        if(month == NUM_FEBRUARY)
         {
-            if (isLeapYear(year) &&
-                    day > MAXIMUM_DAY_FEB_LEAP_YEAR)
+            if(isLeapYear(year) && day > DAY_FEBRUARY_MAXIMUM_LEAP_YEAR)
             {
                 throw new IllegalArgumentException("Invalid day " + day + " for Feb");
             }
-            else if (isLeapYear(year) &&
-                    day > MAXIMUM_DAY_FEBRUARY)
+            else if(isLeapYear(year) && day > DAY_FEBRUARY_MAXIMUM)
             {
                 throw new IllegalArgumentException("Invalid day " + day + " for Feb");
             }
@@ -410,7 +441,9 @@ public class Date
     private static boolean isLeapYear(int year)
     {
         boolean leapYear;
+
         leapYear = year % LEAP_YEAR_CHECK == LEAP_YEAR;
+
         return leapYear;
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # COMP2522-Date-Class
-BCIT's Fall Intake 2024 public repository for the COMP2522 Date.java class
+BCIT's Fall Intake 2024 public repository for the COMP2522 `Date.java` class
 
 Just a fun experiment in how many @author tags we can add to a single Java file.
 


### PR DESCRIPTION
…eTo()`,  removed redundant `else if``.

- Changed formatting
- Changed `MINIMUM_YEAR` & `CURRENT_YEAR` -> `YEAR_MINIMUM` & `YEAR_CURRENT` for readability
- Changed `MINIMUM_MONTH` & `MAXIMUM_MONTH` -> `MONTH_MINIMUM` & `MONTH_MAXIMUM` for readability
- Changed `MINIMUM_DAY` -> `DAY_MINIMUM`, `MAXIMUM_DAY_LONG` -> `DAY_MAXIMUM_LONG`, `MAXIMUM_DAY_SHORT` -> `DAY_MAXIMUM_SHORT`, `MAXIMUM_DAY_FEBRUARY` -> `DAY_FEBRUARY_MAXIMUM`, `MAXIMUM_DAY_FEB_LEAP_YEAR` -> `DAY_FEBRUARY_MAXIMUM_LEAP_YEAR`
- Changed `JANUARY_NUM` -> `NUM_JANUARY` for all months (jan-dec)
- Changed `JANUARY_MONTH_CODE` -> `MONTH_CODE_JANURARY' for all months (jan-dec) for readability
- Changed `SATURDAY_CODE` -> `CODE_SATURDAY` for all days of the week (sun - sat) for readability
- Changed `NUM_OF_DAYS_IN_WEEK` -> `NUM_DAYS_IN_WEEK` for conciseness
- `compareTo()` method formal parameter is now `final`. Formal parameter changed from `d` -> `compareDate` for clarity. Removed redundant `else if`.
- Added Glenn D & Szymon Z to authors
- Incremented version